### PR TITLE
Tighten kGenericSpyPixel regex

### DIFF
--- a/Source/MTBBlockedMessage.m
+++ b/Source/MTBBlockedMessage.m
@@ -326,7 +326,7 @@ NSString *kGenericSpyPixel = @"_Generic Spy Pixel";
         @"Zapier": @[@"opens.zapier.com/q/(.*)/(.*)/(.*)~~"],
         @"Zendesk": @[@"futuresimple.com/api/v1/sprite.png"],
 
-        kGenericSpyPixel: @[@"<img[^>]+(1px|\"1\"|'1')+[^>]*>"]
+        kGenericSpyPixel: @[@"<img[^>]+(width: *1px|\"1\"|'1')+[^>]*>"]
     };
 }
 @end


### PR DESCRIPTION
To allow images with things like 1px borders applied via a style tag, tighten kGenericSpyPixel so that only “width: 1px” is matched rather than any “1px”. The quoted attribute patterns remain as is.

This is untested because I wasn’t able to get Mail.app to enable my locally built plugin, perhaps due to lack of notarization. Let me know if you have any tips on installing the plugin locally.