### PR TITLE
sanitizedHtmlFromHtml nil arg check

### DIFF
--- a/Source/MTBBlockedMessage.m
+++ b/Source/MTBBlockedMessage.m
@@ -51,6 +51,10 @@ NSString *kGenericSpyPixelRegex = @"<img[^>]+(width: *1px|\"1\"|'1')+[^>]*>";
 
 #pragma mark - Helpers
 - (NSString*)sanitizedHtmlFromHtml:(NSString*)html {
+    if (!html) {
+        return nil;
+    }
+    
     NSString *result = html;
     NSDictionary *trackingDict = [self getTrackerDict];
     for (id trackingSourceKey in trackingDict) {


### PR DESCRIPTION
Related to #23 causing #49 CC: @danieldickison

`result/html` is `nil` sometimes. Not sure why atm but this causes an infrequent crash

https://github.com/apparition47/MailTrackerBlocker/blob/091cd4879d642a0072b30c605ed35383aab52c92/Source/MTBBlockedMessage.m#L68