### PR TITLE
postinstall: fix hanging Installer.app on Homebrew installs

### DIFF
--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -51,14 +51,13 @@ if [ "$(printf '%s\n' "$macOSBigSur" "$currentMacOSVer" | sort -V | head -n1)" !
 else
     mtb_log "auto-enabling plugin for $USER (11.x and up only)"
 
-    # if CLI/Homebrew install
+    # if not a CLI/Homebrew install
     GUI_INSTALLER_PID=($(pgrep -u "$USER" -f /System/Library/CoreServices/Installer.app/Contents/MacOS/Installer))
-    if [ -z "$GUI_INSTALLER_PID" ]; then
-        osascript -e 'display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution'
-    else
+    if [ ! -z "$GUI_INSTALLER_PID" ]; then
         # foreground the installer
         osascript -e 'tell application "/System/Library/CoreServices/Installer.app"
         activate
+        display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution
         end tell'        
     fi
 

--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -51,15 +51,15 @@ if [ "$(printf '%s\n' "$macOSBigSur" "$currentMacOSVer" | sort -V | head -n1)" !
 else
     mtb_log "auto-enabling plugin for $USER (11.x and up only)"
 
-    # if not a CLI/Homebrew install
+    # if CLI/Homebrew install
     GUI_INSTALLER_PID=($(pgrep -u "$USER" -f /System/Library/CoreServices/Installer.app/Contents/MacOS/Installer))
-    if [ ! -z "$GUI_INSTALLER_PID" ]; then
+    if [ -z "$GUI_INSTALLER_PID" ]; then
+        osascript -e 'display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution'
+    else
         # foreground the installer
         osascript -e 'tell application "/System/Library/CoreServices/Installer.app"
         activate
-        end tell'
-
-        osascript -e 'display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution'
+        end tell'        
     fi
 
     osascript -e 'on run argv

--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -51,14 +51,17 @@ if [ "$(printf '%s\n' "$macOSBigSur" "$currentMacOSVer" | sort -V | head -n1)" !
 else
     mtb_log "auto-enabling plugin for $USER (11.x and up only)"
 
-    # if not a CLI/Homebrew install
+    # if a GUI install (i.e. not a CLI/Homebrew install)
     GUI_INSTALLER_PID=($(pgrep -u "$USER" -f /System/Library/CoreServices/Installer.app/Contents/MacOS/Installer))
     if [ ! -z "$GUI_INSTALLER_PID" ]; then
         # foreground the installer
         osascript -e 'tell application "/System/Library/CoreServices/Installer.app"
         activate
+
         display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution
-        end tell'        
+        end tell'
+    else
+        osascript -e 'display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 15 with icon caution'
     fi
 
     osascript -e 'on run argv

--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -57,8 +57,6 @@ else
         # foreground the installer
         osascript -e 'tell application "/System/Library/CoreServices/Installer.app"
         activate
-
-        display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution
         end tell'
     fi
 

--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -60,14 +60,14 @@ else
 
         display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution
         end tell'
-    else
-        osascript -e 'display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 15 with icon caution'
     fi
 
     osascript -e 'on run argv
     set src to item 1 of argv as POSIX file
     set dst to item 2 of argv as POSIX file
     set appSupportDir to item 3 of argv as POSIX file
+
+    display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 30 with icon caution
 
     tell application "Finder"
         set folderNames to {"Mail", "Plug-ins", "Bundles", "Library", "Mail", "Bundles"}

--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -51,10 +51,16 @@ if [ "$(printf '%s\n' "$macOSBigSur" "$currentMacOSVer" | sort -V | head -n1)" !
 else
     mtb_log "auto-enabling plugin for $USER (11.x and up only)"
 
-    osascript -e 'tell application "/System/Library/CoreServices/Installer.app"
-    activate
-    display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution
-    end tell'
+    # if CLI install (i.e. homebrew)
+    GUI_INSTALLER_PID=($(pgrep -u "$USER" -f /System/Library/CoreServices/Installer.app/Contents/MacOS/Installer))
+    if [ ! -z "$GUI_INSTALLER_PID" ]; then
+        # foreground the installer
+        osascript -e 'tell application "/System/Library/CoreServices/Installer.app"
+        activate
+        end tell'
+
+        osascript -e 'display dialog "If prompted, please allow the installer to use Finder to enable the plugin." buttons {"OK"} default button 1 giving up after 60 with icon caution'
+    fi
 
     osascript -e 'on run argv
     set src to item 1 of argv as POSIX file

--- a/Packaging/postinstall
+++ b/Packaging/postinstall
@@ -51,7 +51,7 @@ if [ "$(printf '%s\n' "$macOSBigSur" "$currentMacOSVer" | sort -V | head -n1)" !
 else
     mtb_log "auto-enabling plugin for $USER (11.x and up only)"
 
-    # if CLI install (i.e. homebrew)
+    # if not a CLI/Homebrew install
     GUI_INSTALLER_PID=($(pgrep -u "$USER" -f /System/Library/CoreServices/Installer.app/Contents/MacOS/Installer))
     if [ ! -z "$GUI_INSTALLER_PID" ]; then
         # foreground the installer


### PR DESCRIPTION
resolves #106 #194

Call `Installer.app` **only** on GUI install. This avoids the confusing file dialog/Installer popup (#106).