### PR TITLE
ci: release on macOS 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   sign-pack-upload:
 
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
 


### PR DESCRIPTION
issue https://github.com/apparition47/MailTrackerBlocker/issues/211 with the last macOS 14 build. try 15 for next build?